### PR TITLE
lint: update zig format lint paths and add test-fmt build step

### DIFF
--- a/.github/workflows/build-test-zig-master.yml
+++ b/.github/workflows/build-test-zig-master.yml
@@ -35,4 +35,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2
-      - run: zig fmt --check .
+      - run: zig build test-fmt

--- a/build.zig
+++ b/build.zig
@@ -46,7 +46,7 @@ pub fn build(b: *std.Build) !void {
     run_step.dependOn(&run_cmd.step);
 
     // Format
-    const fmt_include_paths = &.{ "doc", "lib", "src", "test", "tools", "build.zig" };
+    const fmt_include_paths = &.{ "lib", "src", "build.zig", "build.zig.zon", "vendor/sdl3" };
     const fmt_exclude_paths = &.{};
     const do_fmt = b.addFmt(.{ .paths = fmt_include_paths, .exclude_paths = fmt_exclude_paths });
     b.step("fmt", "Modify source files in place to have conforming formatting")


### PR DESCRIPTION
Replacing the too generic `zig fmt --check .`