### PR TITLE
ci: Reset pull_request workflow to defaults trigger

### DIFF
--- a/.github/workflows/build-test-zig-master.yml
+++ b/.github/workflows/build-test-zig-master.yml
@@ -8,7 +8,6 @@ on:
     tags: ["*"]
   workflow_dispatch:
   pull_request:
-    types: [opened, edited, reopened]
 
 # Simply build and run the tests
 jobs:


### PR DESCRIPTION
It was missing the synchronize one and having the unrelated edited. Fixing both reverts back to default.